### PR TITLE
Update README to include example error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Compile-time checked Builder pattern `derive` macro with zero-memory overhead
+>  *This is very much a work-in-progress. PRs welcome to bring this to production quality welcome.*
 
 The [Builder Pattern](https://en.wikipedia.org/wiki/Builder_pattern) is a design pattern to allow the construction of complex types one field at a time by calling methods on a builder type. This crate provides a `derive` macro that allows you to annotate any `struct` to create a type-level state machine that requires all mandatory fields to be set once and only at compile-time (otherwise you won't be able to call `.build()` on it).
 
@@ -24,4 +25,7 @@ You can look at the `examples` directory for a showcase of the available feature
 
 The created `Builder` type has zero-memory overhead because it uses a [`MaybeUninit` backed field](https://lucumr.pocoo.org/2022/1/30/unsafe-rust/) of the type to be built.
 
-*This is very much a work-in-progress. PRs welcome to bring this to production quality welcome.*
+## Error messages
+One of the main downsides of the typestate pattern are inscrutable error messages. However, the since this crate generates type-state parameters with readable names, rustc can produce readable error messages:
+![image](https://user-images.githubusercontent.com/492903/154131011-1bb5d95b-b00d-4ce6-8683-d86a01edd58f.png)
+


### PR DESCRIPTION
The first thing I tried to find was the error messages, ended up finding them in the tweet. Copied the image into the README and brought the disclaimer to the top so it doesn't get lost as the README gets longer