### PR TITLE
Do not emit the parentheses wrapping the default value with `#[default(...)]`

### DIFF
--- a/makeit-derive/Cargo.toml
+++ b/makeit-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "makeit-derive"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2018"
 authors = ["Esteban Küber <esteban@kuber.com.ar>"]
 license = "MIT"

--- a/makeit-derive/src/lib.rs
+++ b/makeit-derive/src/lib.rs
@@ -225,6 +225,16 @@ pub fn derive_builder(input: TokenStream) -> TokenStream {
                 if default.is_empty() {
                     quote!(builder.#field(::std::default::Default::default());)
                 } else {
+                    let mut default_iter = default.clone().into_iter();
+                    let default = match [default_iter.next(), default_iter.next()] {
+                        [Some(proc_macro2::TokenTree::Group(group)), None]
+                            if group.delimiter() == proc_macro2::Delimiter::Parenthesis =>
+                        {
+                            group.stream()
+                        }
+                        _ => syn::Error::new_spanned(default, "expected `#[default(…)]`")
+                            .into_compile_error(),
+                    };
                     quote!(builder.#field(#default);)
                 }
             })

--- a/makeit/Cargo.toml
+++ b/makeit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "makeit"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2018"
 authors = ["Esteban Küber <esteban@kuber.com.ar>"]
 license = "MIT"


### PR DESCRIPTION
This fixes the compiler suggestions; see rust-lang/rust#94074.

Technically this is a breaking change - previously, because of the parentheses, you could actually pass a tuple as the default value without wrapping it in parentheses - e.g. `#[default(1, 1)]`. Now you need to do `#[default((1, 1))]`. However, I don't think someone relied on this, as it looks like the wrong behavior.