### PR TITLE
Fix `r#` fields not working

### DIFF
--- a/makeit-derive/src/lib.rs
+++ b/makeit-derive/src/lib.rs
@@ -6,7 +6,8 @@ use quote::ToTokens;
 use syn::spanned::Spanned;
 use syn::{GenericParam, ItemStruct, Visibility};
 
-fn capitalize(s: &str) -> String {
+fn capitalize(mut s: &str) -> String {
+    s = s.trim_start_matches("r#");
     let mut c = s.chars();
     match c.next() {
         None => String::new(),


### PR DESCRIPTION
Fields with `r#` prefixed didn't work due to the `capitalize` function not handling the prefix.
Eg:
```rust
#[derive(Buildable)]
struct Foo {
  r#type: String,
}
```

This PR fixes the issue by stripping the `r#` when capitalizing the ident.

_I suggest merging this as a squashed merge combining the commits into one._